### PR TITLE
[Fix] #54 - 납품서 목록에서 출고지시 작성으로 넘어가지 않던 버그 수정

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -239,8 +239,9 @@ const router = createRouter({
                 },
                 {
                     path: "warehouse/goods-issues/create/:doCode",
+                    name: "GoodsIssueCreate",
                     component: GoodsIssueCreate,
-                    meta: { roles: ["AC_WHS", "AC_SYS"] },
+                    meta: { roles: ["AC_SAL", "AC_WHS", "AC_SYS"] },
                 },
                 {
                     path: "warehouse/goods-issues/:giCode",

--- a/src/views/warehouse/GoodsIssueCreate.vue
+++ b/src/views/warehouse/GoodsIssueCreate.vue
@@ -164,7 +164,13 @@ const submitGoodsIssue = async () => {
         })
 
         alert(response.message || '출고지시가 등록되었습니다.')
-        router.push('/warehouse/goods-issues')
+
+        // 생성된 출고지시 상세 페이지로 이동
+        if (response.giCode) {
+            router.push(`/warehouse/goods-issues/${response.giCode}`)
+        } else {
+            router.push('/warehouse/goods-issues')
+        }
     } catch (err) {
         console.error('출고지시 등록 실패:', err)
         const errorMessage = err.response?.data?.message || '출고지시 등록에 실패했습니다.'


### PR DESCRIPTION
## Pull Request
### ISSUE
- #54

### Develop
- 출고지시를 작성하기 위해 납품서를 선택할 때 페이지가 넘어가지지 않던 오류 수정
- 출고지시 작성 페이지의 권한 추가(영업팀)
- 출고지시 작성 완료 시 해당 출고지시의 상세 페이지로 이동되도록 추가

### Test
수정 이후 정상 실행 됩니다