### PR TITLE
[Fix] #56 - 출고지시의 결재상신을 결재페이지에서 수행하도록 수정

### DIFF
--- a/src/views/warehouse/GoodsIssueDetail.vue
+++ b/src/views/warehouse/GoodsIssueDetail.vue
@@ -251,7 +251,7 @@
                         <div class="flow-step">
                             <div class="flow-circle completed">기안</div>
                             <div class="flow-info">
-                                <div class="flow-label">기안</div>
+                                <div class="flow-label">{{ giDetail.managerName || '기안' }} · {{ giDetail.managerDepartment || '-' }}</div>
                             </div>
                         </div>
 
@@ -295,7 +295,7 @@
                                 <td>{{ giDetail.managerName || '-' }}</td>
                                 <td>{{ formatRole(giDetail.managerRank, giDetail.managerPosition) }}</td>
                                 <td>{{ giDetail.managerDepartment || '-' }}</td>
-                                <td><span class="status-text approved">승인</span></td>
+                                <td><span class="status-text approved">상신</span></td>
                                 <td>{{ formatDateTime(giDetail.createdAt) }}</td>
                                 <td>-</td>
                             </tr>


### PR DESCRIPTION
## Pull Request
### ISSUE
- #56 

### Develop
- 기존엔 출고지시 상세 페이지에서 모달창을 열어서 결재선을 지정하게 했었는데
아예 결재 페이지로 이동해서 결재를 진행 할 수 있게 수정했습니다.(새 창으로 결재 페이지 열림)

- 결재선 기안자의 정보가 출고지시서를 작성한 지시자(영업팀) 직원의 정보로 출력되던 오류 수정

### Test
<img width="1882" height="1008" alt="image" src="https://github.com/user-attachments/assets/c7b769ea-889d-40c8-b133-9be393a2cb99" />

<img width="1629" height="645" alt="image" src="https://github.com/user-attachments/assets/0dc6352d-153e-4198-bf9c-4ac12bd542b8" />

